### PR TITLE
Modified attacks

### DIFF
--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -1347,9 +1347,9 @@ fighter.prototype = {
         var attacker = this;
         var target = battlefield.getTarget();
         var baseDamage = roll / 2; //Not directly affected by crits
-        var damage = Math.max(attacker.dexterity() / 2, attacker.strength());	//Affected by crits and the like
+        var damage = Math.max( (attacker.strength() + attacker.dexterity()) / 2, attacker.strength());	//Affected by crits and the like
         var stamDamage = attacker.spellpower(); //This value + damage is drained from the targets stamina if the attack is successful
-        var requiredStam = 20;
+        var requiredStam = 15;
         var difficulty = 1;
 
         if (attacker.isDisoriented) difficulty += 1; //Up the difficulty if the attacker is dizzy.
@@ -1696,8 +1696,8 @@ fighter.prototype = {
         var attacker = this;
         var target = battlefield.getTarget();
         var baseDamage = roll;
-        var damage = Math.max(attacker.dexterity() / 2, attacker.spellpower());
-        var requiredStam = 20;
+        var damage = Math.max( (attacker.dexterity() + attacker.strength()) / 2, (attacker.dexterity() + attacker.spellpower()) / 2);
+        var requiredStam = 25;
         var difficulty = 8; //Base difficulty, rolls greater than this amount will hit.
 
         if (attacker.isDisoriented) difficulty += 3; //Up the difficulty considerably if the attacker is dizzy.
@@ -1757,9 +1757,9 @@ fighter.prototype = {
     actionMagic: function (roll) {
         var attacker = this;
         var target = battlefield.getTarget();
-        var baseDamage = roll / 2 + attacker.spellpower();
+        var baseDamage = roll;
         var damage = 2 * attacker.spellpower();
-        var requiredMana = 24;
+        var requiredMana = 20;
         var difficulty = 8; //Base difficulty, rolls greater than this amount will hit.
 
         if (attacker.isRestrained) difficulty += Math.max(2, 4 + Math.floor((target.strength() - attacker.strength()) / 2)); //When grappled, up the difficulty based on the relative strength of the combatants. Minimum of +2 difficulty, maximum of +8.
@@ -1780,7 +1780,7 @@ fighter.prototype = {
         }
         // attacker.hitMana (requiredMana); //Now that required mana has been checked, reduce the attacker's mana by the appopriate amount.
 
-        var attackTable = attacker.buildActionTable(difficulty, target.dexterity(), attacker.dexterity(), attacker.spellpower());
+        var attackTable = attacker.buildActionTable(difficulty, target.dexterity(), attacker.dexterity(), attacker.dexterity());
 
         if (roll <= attackTable.miss) {	//Miss-- no effect.
             windowController.addHit(" FAILED! ");


### PR DESCRIPTION
This is a bit of a test for me figuring out pull requests. So here are a few changes I though about in the past days.

Using either STR or DEX/2 for the damage of light attack encouraged people to min-max and create DEX builds with 1 STR. Using the average of STR and DEX as an alternative to pure STR should still provide DEX builds an incentive to use Light, but now they'll profit from having a bit of STR too. Hopefully that will lead to more natural attribute spread. Reduced Stamina cost is there to compensate for light being the weakest attack and encourage people to use it more.

The rationale for the change to ranged is somewhat related. While the idea was to chose between weaker accurate attacks and stronger inaccurate attacks, that was not the case in practice. Everyone went either with very high DEX or if they had very high SPW they just went full mage. The proposed change would have ranged simulate two possibilities. Bows, guns, and thrown weapons all require strength IRL, so it makes sense to include it. The justification for higher STR giving more damage with guns is that it allows the fighter to use guns of a larger caliber. The DEX & SPW combo on the other hand would serve to represent attacks with energy weapons such as lasers or basic magical spells. The increased cost is there to make up for the potentially increased damage and because Ranged used to be too efficient in the amount of damage you can do with your stamina. This would put it halfway between Light and Heavy in cost, which seems fitting given that it's also halfway between them in damage.

The change to magic is to make the mage builds less extreme. Right now every other wizard has 10 SPW because it just scales the damage of Magic so much. A 10 SPW mage will do upwards of 30 damage even on poor rolls. Additionally a problem with Magic was that it used a single attribute for both attack and damage, which just added to the problem. The change to the attack table should bring it in line with all other attacks.

All this hurts mages considerably and I don't think they are actually too strong (win rate certainly doesn't suggest that), so making Magic cheaper should offset the reduced reliability and the new reliance on DEX for attacks.
