### PR TITLE
Rework of Grab, Move, Focus + minor changes to Magic and hit calculation process

### DIFF
--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -1373,9 +1373,9 @@ fighter.prototype = {
         }
         // Basing hit chance on difference multiplied by rangeMulti so that we have ideal DEX difference rather than ideal absolute DEX value.
         if (attackerDex > targetDex) {
-            attackTable.dodge = difficulty + Math.floor((targetDex - attackerDex) * rangeMult); //Used floor to make the result a more negative value.
+            attackTable.dodge = difficulty + Math.floor((targetDex - attackerHitBonus) * rangeMult); //Used floor to make the result a more negative value.
         } else {
-            attackTable.dodge = difficulty + Math.ceil((targetDex - attackerDex) * rangeMult);
+            attackTable.dodge = difficulty + Math.ceil((targetDex - attackerHitBonus) * rangeMult);
         }
         //attackTable.dodge = attackTable.miss + Math.ceil(targetDex * rangeMult); //9
         attackTable.glancing = attackTable.dodge + Math.floor(((targetDex * 2) - attackerDex) * rangeMult);
@@ -1445,6 +1445,11 @@ fighter.prototype = {
         //Deal all the actual damage/effects here.
 
         attacker.hitStamina(requiredStam);
+        
+        if (inGrabRange) {
+            inGrabRange = false;
+            windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+        }
 
         damage += baseDamage;
         damage = Math.max(damage, 1);
@@ -1519,6 +1524,11 @@ fighter.prototype = {
         //Deal all the actual damage/effects here.
 
         attacker.hitStamina(requiredStam);
+        
+        if (inGrabRange) {
+            inGrabRange = false;
+            windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+        }
 
         damage += baseDamage;
         damage = Math.max(damage, 1);
@@ -1612,7 +1622,7 @@ fighter.prototype = {
         }
 
         //Deal all the actual damage/effects here.
-        attacker.hitStamina(requiredStam - 15); //Successful grab attacks have the cost reduced
+        attacker.hitStamina(requiredStam); //Successful grab attacks have the cost reduced
 
         damage += baseDamage;
         damage = Math.max(damage, 1);
@@ -1710,6 +1720,7 @@ fighter.prototype = {
 
         if (attacker.isGrappling(target)) {
             target.removeGrappler(attacker);
+            inGrabRange = false;
             if (target.isGrappling(attacker)) {
                 attacker.removeGrappler(target);
                 windowController.addHit(attacker.name + " gained the upper hand and THREW " + target.name + "! " + attacker.name + " can make another move! " + attacker.name + " is no longer at a penalty from being grappled!");
@@ -1719,9 +1730,11 @@ fighter.prototype = {
             windowController.addHint(target.name + ", you are no longer grappled. You should make your post, but you should only emote being hit, do not try to perform any other actions.");
         } else if (target.isGrappling(attacker)) {
             attacker.removeGrappler(target);
+            inGrabRange = false;
             windowController.addHit(attacker.name + " found a hold and THREW " + target.name + " off! " + attacker.name + " can make another move! " + attacker.name + " is no longer at a penalty from being grappled!");
             windowController.addHint(target.name + ", you should make your post, but you should only emote being hit, do not try to perform any other actions.");
         } else {
+            inGrabRange = true;
             windowController.addHit(attacker.name + " TACKLED " + target.name + ". " + attacker.name + " can take another action while their opponent is stunned!");
             windowController.addHint(target.name + ", you should make your post, but you should only emote being hit, do not try to perform any other actions.");
         }
@@ -1796,6 +1809,12 @@ fighter.prototype = {
         //Deal all the actual damage/effects here.
 
         attacker.hitStamina(requiredStam);
+        
+        if (inGrabRange) {
+            inGrabRange = false;
+            windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+        }
+        
         damage += baseDamage;
         damage = Math.max(damage, 1);
         target.hitHp(damage);
@@ -1862,6 +1881,11 @@ fighter.prototype = {
         //Deal all the actual damage/effects here.
 
         attacker.hitMana(requiredMana);
+        
+        if (inGrabRange) {
+            inGrabRange = false;
+            windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+        }
 
         damage += baseDamage;
         damage = Math.max(damage, 1);

--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -1278,7 +1278,7 @@ fighter.prototype = {
 
         if (this._manaCap == this._maxMana) this.manaBurn = 0;
 
-        if (this.isUnconscious == false) {
+        if (this.isUnconscious == false) {//We removed evading attacks status, so we no longer have to check for it.
             var stamBonus = 2 + this.endurance();
             this.addStamina(stamBonus);
             var manaBonus = 2 + this.willpower();

--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -1143,7 +1143,7 @@ function fighter(settings, globalSettings) {
     this.isDisoriented = 0;
     this.isGrappledBy = [];
     this.isFocused = 0;
-    this.isEscaping = 0;
+    this.isEscaping = 0;//A bonus to escape attempts that increases whenever you fail one.
     //this.isEvading = false;
 };
 
@@ -1995,7 +1995,8 @@ fighter.prototype = {
         }
         return 1; //Successful attack, if we ever need to check that.
 
-        if (attacker.isRestrained) difficulty += Math.max(0, 2 + Math.floor((target.strength() - attacker.strength()) / 2)); //When grappled, up the difficulty based on the relative strength of the combatants. Minimum of +0 difficulty, maximum of +6.
+        if (attacker.isRestrained) difficulty += Math.max(2, 6 + Math.floor((target.strength() - attacker.strength()) / 2)); //When grappled, up the difficulty based on the relative strength of the combatants. Minimum of +2 difficulty, maximum of +10.
+        if (attacker.isRestrained) difficulty -= attacker.isEscaping; //Then reduce difficulty based on how much effort we've put into escaping so far.
         if (target.isRestrained) difficulty -= 4; //Lower the difficulty considerably if the target is restrained.
 
         if (attacker.isDisoriented) difficulty += 2; //Up the difficulty if the attacker is dizzy.
@@ -2018,12 +2019,14 @@ fighter.prototype = {
 
         if (roll <= attackTable.miss) {	//Miss-- no effect.
             windowController.addHit("FAILED! ");
+            attacker.isEscaping += 4;
             return 0; //Failed attack, if we ever need to check that.
         }
 
         if (roll <= attackTable.dodge && target.canDodge(attacker)) {	//Dodged-- no effect.
             windowController.addHit(target.name + " WAS TOO QUICK! ");
             windowController.addHint(attacker.name + " failed. " + target.name + " was just too quick for them.");
+            attacker.isEscaping += 4;
             return 0; //Failed attack, if we ever need to check that.
         }
 
@@ -2048,6 +2051,7 @@ fighter.prototype = {
         if (target.isGrappling(attacker)) { //If you were being grappled, you get free.
             windowController.addHint(attacker.name + " escaped " + target.name + "'s hold! ");
             attacker.removeGrappler(target);
+            attacker.isEscaping = 0;
             tempGrappleFlag = false;
         }
 

--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -1396,10 +1396,10 @@ fighter.prototype = {
 
         if (attacker.isDisoriented) difficulty += 2; //Up the difficulty if the attacker is dizzy.
         if (attacker.isRestrained) difficulty += 2; //Up the difficulty if the attacker is restrained.
-        if (target.isFocused) difficulty += 2;
+        //if (target.isFocused) difficulty += 2;
         if (target.isDisoriented) difficulty -= 2; //Lower the difficulty if the target is dizzy.
         if (target.isRestrained) difficulty -= 2; //Lower it if the target is restrained.
-        if (attacker.isFocused) difficulty -= 2; //Lower the difficulty if the attacker is focused.
+        if (attacker.isFocused) difficulty -= 4; //Lower the difficulty if the attacker is focused.
 
         if (attacker.stamina < requiredStam) {	//Not enough stamina-- reduced effect
             damage *= attacker.stamina / requiredStam;
@@ -1476,10 +1476,10 @@ fighter.prototype = {
 
         if (attacker.isDisoriented) difficulty += 2; //Up the difficulty if the attacker is dizzy.
         if (attacker.isRestrained) difficulty += 2; //Up the difficulty if the attacker is restrained.
-        if (target.isFocused) difficulty += 2;
+        //if (target.isFocused) difficulty += 2;
         if (target.isDisoriented) difficulty -= 2; //Lower the difficulty if the target is dizzy.
         if (target.isRestrained) difficulty -= 2; //Lower it if the target is restrained.
-        if (attacker.isFocused) difficulty -= 2; //Lower the difficulty if the attacker is focused
+        if (attacker.isFocused) difficulty -= 4; //Lower the difficulty if the attacker is focused
 
         var critCheck = true;
         if (attacker.stamina < requiredStam) {	//Not enough stamina-- reduced effect
@@ -1549,17 +1549,17 @@ fighter.prototype = {
         var baseDamage = roll / 4;
         var damage = attacker.strength() / 2;
         var requiredStam = 20;
-        var difficulty = 4; //Base difficulty, rolls greater than this amount will hit.
+        var difficulty = 6; //Base difficulty, rolls greater than this amount will hit.
 
         //if (attacker.isRestrained) difficulty += 2; //Up the difficulty slightly if the attacker is restrained.
         //if (target.isRestrained) difficulty += 2; //Submission moves are more difficult
 
-        if (target.isRestrained) difficulty += Math.max(4, 6 + Math.floor((target.strength() - attacker.strength()) / 2)); //Up the difficulty of submission moves based on the relative strength of the combatants. Minimum of +0 difficulty, maximum of +8.
+        if (target.isRestrained) difficulty += Math.max(2, 4 + Math.floor((target.strength() - attacker.strength()) / 2)); //Up the difficulty of submission moves based on the relative strength of the combatants. Minimum of +0 difficulty, maximum of +8.
 
         if (attacker.isDisoriented) difficulty += 2; //Up the difficulty if the attacker is dizzy.
         if (target.isDisoriented) difficulty -= 2; //Lower the difficulty if the target is dizzy.
-        if (target.isFocused) difficulty += 2; // Up the difficulty if the target is focused
-        if (attacker.isFocused) difficulty -= 2; //Lower the difficulty if the attacker is focused
+        //if (target.isFocused) difficulty += 2; // Up the difficulty if the target is focused
+        if (attacker.isFocused) difficulty -= 4; //Lower the difficulty if the attacker is focused
 
         var critCheck = true;
         if (attacker.stamina < requiredStam) {	//Not enough stamina-- reduced effect
@@ -1607,15 +1607,16 @@ fighter.prototype = {
             windowController.addHint(target.name + " put up quite a struggle, costing " + attacker.name + " additional stamina. ");
             attacker.hitStamina(10 + target.strength());
         } else if (roll >= attackTable.crit && critCheck) { //Critical Hit-- increased damage/effect, typically 3x damage if there are no other bonuses.
-            windowController.addHint("Critical! " + attacker.name + " found a particularly damaging hold!");
-            damage *= 2;
+            windowController.addHint("Critical! " + attacker.name + " found a particularly good hold and " + target.name + " lost stamina!");
+            //damage *= 2;
+            target.hitStamina(10 + attacker.strength()); //Half STR extra damage is too low for a crit. Better to damage opponent's stamina.
         }
 
         if (attacker.isGrappling(target)) {
             windowController.addHit(" SUBMISSION ");
             damage += attacker.strength() * 2;
             target.isDisoriented += 2; //Submission moves disorient the target.
-            target.isEscaping -= 2; //Submission moves make it harder to escape.
+            target.isEscaping -= 3; //Submission moves make it harder to escape.
             if (target.isGrappling(attacker)) {
                 attacker.removeGrappler(target);
                 windowController.addHint(target.name + " is in a SUBMISSION hold, taking damage and suffering disorientation from the pain. " + attacker.name + " is also no longer at a penalty from being grappled!");
@@ -1672,9 +1673,9 @@ fighter.prototype = {
 
         if (attacker.isDisoriented) difficulty += 2; //Up the difficulty if the attacker is dizzy.
         //if (target.isEvading) difficulty += 4; //Increase the difficulty if the target is not in melee, but don't make it impossible.
-        if (target.isFocused) difficulty += 2;
+        //if (target.isFocused) difficulty += 2;
         if (target.isDisoriented) difficulty -= 2; //Lower the difficulty if the target is dizzy.
-        if (attacker.isFocused) difficulty -= 2; //Lower the difficulty if the attacker is focused
+        if (attacker.isFocused) difficulty -= 4; //Lower the difficulty if the attacker is focused
 
         // if (target.isEvading) requiredStam += 20; //Increase the stamina cost if the target is not in melee
 
@@ -1696,7 +1697,7 @@ fighter.prototype = {
 
         if (roll <= attackTable.miss) {	//Miss-- no effect.
             windowController.addHit(" MISS! ");
-            if (attacker.isRestrained) attacker.isEscaping += 4;//If we fail to escape, it'll be easier next time.
+            if (attacker.isRestrained) attacker.isEscaping += 6;//If we fail to escape, it'll be easier next time.
             attacker.hitStamina(requiredStam);
             return 0; //Failed attack, if we ever need to check that.
         }
@@ -1704,7 +1705,7 @@ fighter.prototype = {
         if (roll <= attackTable.dodge && target.canDodge(attacker)) {	//Dodged-- no effect.
             windowController.addHit(" DODGE! ");
             windowController.addHint(target.name + " dodged the attack. ");
-            if (attacker.isRestrained) attacker.isEscaping += 4;//If we fail to escape, it'll be easier next time.
+            if (attacker.isRestrained) attacker.isEscaping += 6;//If we fail to escape, it'll be easier next time.
             attacker.hitStamina(requiredStam);
             return 0; //Failed attack, if we ever need to check that.
         }
@@ -1770,7 +1771,7 @@ fighter.prototype = {
 
         if (attacker.isDisoriented) difficulty += 2; //Up the difficulty considerably if the attacker is dizzy.
         if (attacker.isRestrained) difficulty += 4; //Up the difficulty considerably if the attacker is restrained.
-        if (target.isFocused) difficulty += 4;
+        //if (target.isFocused) difficulty += 4;
         if (target.isDisoriented) difficulty -= 2; //Lower the difficulty if the target is dizzy.
         if (target.isRestrained) difficulty -= 2; //Lower the difficulty slightly if the target is restrained.
         if (attacker.isFocused) difficulty -= 4; //Lower the difficulty considerably if the attacker is focused
@@ -1834,7 +1835,7 @@ fighter.prototype = {
     actionMagic: function (roll) {
         var attacker = this;
         var target = battlefield.getTarget();
-        var baseDamage = roll - 2 * target.spellpower();
+        var baseDamage = roll - target.spellpower();
         var damage = 2 * attacker.spellpower();
         var requiredMana = 20;
         var difficulty = 8; //Base difficulty, rolls greater than this amount will hit.
@@ -1843,7 +1844,7 @@ fighter.prototype = {
         if (target.isRestrained) difficulty -= 2; //Lower the difficulty considerably if the target is restrained.
 
         if (attacker.isDisoriented) difficulty += 2; //Up the difficulty if the attacker is dizzy.
-        if (target.isFocused) difficulty += 4;
+        //if (target.isFocused) difficulty += 4;
         if (target.isDisoriented) difficulty -= 2; //Lower the difficulty if the target is dizzy.
         if (attacker.isFocused) difficulty -= 4; //Lower the difficulty if the attacker is focused
 
@@ -1857,7 +1858,7 @@ fighter.prototype = {
         }
         // attacker.hitMana (requiredMana); //Now that required mana has been checked, reduce the attacker's mana by the appopriate amount.
 
-        var attackTable = attacker.buildActionTable(difficulty, target.dexterity(), attacker.dexterity(), attacker.dexterity());
+        var attackTable = attacker.buildActionTable(difficulty, target.dexterity(), attacker.dexterity(), attacker.willpower());//Magic now uses willpower to determine hitting & missing, but DEX still decides critical and glancing hits.
         windowController.addInfo("Dice Roll Required: " + (attackTable.dodge +1));
 
         if (roll <= attackTable.miss) {	//Miss-- no effect.
@@ -2030,14 +2031,14 @@ fighter.prototype = {
 
         if (roll <= attackTable.miss) {	//Miss-- no effect.
             windowController.addHit("FAILED! ");
-            if (attacker.isRestrained) attacker.isEscaping += 4;//If we fail to escape, it'll be easier next time.
+            if (attacker.isRestrained) attacker.isEscaping += 6;//If we fail to escape, it'll be easier next time.
             return 0; //Failed attack, if we ever need to check that.
         }
 
         if (roll <= attackTable.dodge && target.canDodge(attacker)) {	//Dodged-- no effect.
             windowController.addHit(target.name + " WAS TOO QUICK! ");
             windowController.addHint(attacker.name + " failed. " + target.name + " was just too quick for them.");
-            if (attacker.isRestrained) attacker.isEscaping += 4;//If we fail to escape, it'll be easier next time.
+            if (attacker.isRestrained) attacker.isEscaping += 6;//If we fail to escape, it'll be easier next time.
             return 0; //Failed attack, if we ever need to check that.
         }
 

--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -1448,9 +1448,11 @@ fighter.prototype = {
 
         attacker.hitStamina(requiredStam);
         
-        if (inGrabRange) {// Succesful attacks will beat back the grabber before they can grab you.
-            inGrabRange = false;
-            windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+        if (inGrabRange) {// Succesful attacks will beat back the grabber before they can grab you, but not if you're already grappling.
+            if (!attacker.isRestrained && !target.isRestrained) {
+                inGrabRange = false;
+                windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+            }
         }
 
         damage += baseDamage;
@@ -1527,9 +1529,11 @@ fighter.prototype = {
 
         attacker.hitStamina(requiredStam);
         
-        if (inGrabRange) {// Succesful attacks will beat back the grabber before they can grab you.
-            inGrabRange = false;
-            windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+        if (inGrabRange) {// Succesful attacks will beat back the grabber before they can grab you, but not if you're already grappling.
+            if (!attacker.isRestrained && !target.isRestrained) {
+                inGrabRange = false;
+                windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+            }
         }
 
         damage += baseDamage;
@@ -1545,12 +1549,12 @@ fighter.prototype = {
         var baseDamage = roll / 4;
         var damage = attacker.strength() / 2;
         var requiredStam = 20;
-        var difficulty = 8; //Base difficulty, rolls greater than this amount will hit.
+        var difficulty = 4; //Base difficulty, rolls greater than this amount will hit.
 
         //if (attacker.isRestrained) difficulty += 2; //Up the difficulty slightly if the attacker is restrained.
         //if (target.isRestrained) difficulty += 2; //Submission moves are more difficult
 
-        if (target.isRestrained) difficulty += Math.max(0, 2 + Math.floor((target.strength() - attacker.strength()) / 2)); //Up the difficulty of submission moves based on the relative strength of the combatants. Minimum of +0 difficulty, maximum of +8.
+        if (target.isRestrained) difficulty += Math.max(4, 6 + Math.floor((target.strength() - attacker.strength()) / 2)); //Up the difficulty of submission moves based on the relative strength of the combatants. Minimum of +0 difficulty, maximum of +8.
 
         if (attacker.isDisoriented) difficulty += 2; //Up the difficulty if the attacker is dizzy.
         if (target.isDisoriented) difficulty -= 2; //Lower the difficulty if the target is dizzy.
@@ -1813,9 +1817,11 @@ fighter.prototype = {
 
         attacker.hitStamina(requiredStam);
         
-        if (inGrabRange) {//A counter-attack will push a grappler back.
-            inGrabRange = false;
-            windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+        if (inGrabRange) {// Succesful attacks will beat back the grabber before they can grab you, but not if you're already grappling.
+            if (!attacker.isRestrained && !target.isRestrained) {
+                inGrabRange = false;
+                windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+            }
         }
         
         damage += baseDamage;
@@ -1885,9 +1891,11 @@ fighter.prototype = {
 
         attacker.hitMana(requiredMana);
         
-        if (inGrabRange) {//A counter-attack will push a grappler back.
-            inGrabRange = false;
-            windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+        if (inGrabRange) {// Succesful attacks will beat back the grabber before they can grab you, but not if you're already grappling.
+            if (!attacker.isRestrained && !target.isRestrained) {
+                inGrabRange = false;
+                windowController.addHit(attacker.name + " knocked " + target.name + " back with the attack and they are no longer in grappling range!");
+            }
         }
 
         damage += baseDamage;

--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -1966,6 +1966,11 @@ fighter.prototype = {
         //    return 1;
         //}
 
+        if (!inGrabRange && !attacker.isGrappled) { //If you were neither grappled nor in grab range, you didn't need to do this.
+            windowController.addHint(attacker.name + " was neither grappled nor in grapple range and just wasted a turn.");
+        }
+        return 1; //Successful attack, if we ever need to check that.
+
         if (attacker.isRestrained) difficulty += Math.max(0, 2 + Math.floor((target.strength() - attacker.strength()) / 2)); //When grappled, up the difficulty based on the relative strength of the combatants. Minimum of +0 difficulty, maximum of +6.
         if (target.isRestrained) difficulty -= 4; //Lower the difficulty considerably if the target is restrained.
 
@@ -2022,10 +2027,14 @@ fighter.prototype = {
             tempGrappleFlag = false;
         }
 
-        //if (tempGrappleFlag) { //If you weren't grappling or being grappled, try to evade.
+        if (tempGrappleFlag) { //If you weren't grappling or being grappled but you were in grapple range, move out of grapple range.
+            if (inGrabRange) {
+                inGrabRange = false;
+                windowController.addHint(attacker.name + " managed to put some distance between them and " + target.name + " and is now out of grabbing range.");
+            }
         //    windowController.addHint(attacker.name + " managed to put some distance between them and " + target.name + ". " + attacker.name + " is now actively evading melee, at the cost of their normal stamina regen.");
         //    attacker.isEvading = true;
-        //}
+        }
         return 1; //Successful attack, if we ever need to check that.
     },
 

--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -1325,6 +1325,7 @@ fighter.prototype = {
 
         if (this.isRestrained) windowController.addHint(this.name + " is Grappled.");
         if (this.isFocused) windowController.addHint(this.name + " is Aimed/Focused.");
+        if (inGrabRange) windowController.addHint("The fighters are in grappling range");//Added notification about fighters ebing in grappling range.
         //if (this.isEvading) windowController.addHint(this.name + " is keeping their distance.");
         return message;
     },

--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -2084,7 +2084,7 @@ fighter.prototype = {
                 attacker.hitStamina(35);
                 break;
             case "Grab":
-                attacker.hitStamina(25);
+                attacker.hitStamina(20);
                 break;
             case "Tackle":
                 attacker.hitStamina(35);

--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -1828,7 +1828,7 @@ fighter.prototype = {
     actionMagic: function (roll) {
         var attacker = this;
         var target = battlefield.getTarget();
-        var baseDamage = roll - target.spellpower();
+        var baseDamage = roll - 2 * target.spellpower();
         var damage = 2 * attacker.spellpower();
         var requiredMana = 20;
         var difficulty = 8; //Base difficulty, rolls greater than this amount will hit.


### PR DESCRIPTION
You'd better doublecheck or even triplecheck this before merging, but I think it should be fine. I tried to comment all the changes I did.
1. Grab now works in two stages. Stage 1 is to get into grappling range which can be done either with grab or with tackle. If you then take damage from your opponent before you managed to grab, you're pushed out of grapple range and have to start over. Opponent can also choose to try and Move away. If they fail to do either of those two things you can then grab them like normal, except with lower difficulty and lower cost of failure. Submission moves still have the same difficulty as before.
2. The use of Move to evade attacks has been commented away.
3. Escaping Grabs is now harder than before initially, but each failed attempt to do so with either Move/Escape or Tackle reduces the difficulty of the next Move/Escape by 6. If the grabber uses submission that reduces the bonus by 3. However, the bonus can't be negative, which is taken care of during turn update (along with clearing it if you're no longer grabbed).
4. I also touched the hit formula a little, to make it so attack bonus attribute is used in hit calculations. This shouldn't change anything for most actions, but lays the foundation for point #5.
5. Changed Magic to use Willpower to calculate hits, but it still uses DEX to determine critical and glancing hits.
6. Focus is now -4 to difficulty of all attacks and is intended to be used as a counter to high DEX. It no longer gives a defensive bonus.
