### PR TITLE
Hex fix

### DIFF
--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -2216,8 +2216,10 @@ fighter.prototype = {
         damage = Math.max(damage, 1);
         target.hitHp(damage);
         target.hitCloth(3);
-        if (target.hasMagicWeakness < attacker.spellpower()) target.hasMagicWeakness += 1;//The hex reduces resistance against further magical attacks by at least 1 point.
-        windowController.addHit(attacker.name + " increased " + target.name + "'s weakness to magic by " + Math.max(1, hexDamage) + "!");
+        if (target.hasMagicWeakness < attacker.spellpower()) {
+            target.hasMagicWeakness += 1;//The hex reduces resistance against further magical attacks by 1 point.
+            windowController.addHit(attacker.name + " increased " + target.name + "'s weakness to magic!");
+        }
         return 1; //Successful attack, if we ever need to check that.
     },
 


### PR DESCRIPTION
I'm not sure this will solve all problems, but it should fix Hex specifically. There used to be a hexDamage variable used to determine just how much Hex increased Magic Weakness in one intermediary version of the code. I later decided to just have it go up by 1 and deleted the line where hexDamage was declared, but forgot to remove it from the info line which puts out the text describing how much Hex increased magic weakness.