### PR TITLE
bugfix

### DIFF
--- a/plugins/RendezVousFighting.js
+++ b/plugins/RendezVousFighting.js
@@ -2526,7 +2526,7 @@ fighter.prototype = {
 
         windowController.addInfo("Dice Roll Required: " + Math.max(2, (difficulty + 1)));
         var manaShift = 10 + (roll * 2) + (attacker.willpower() * 3);
-        manaShift = Math.min(manaShift, attacker.stamina);
+        //manaShift = Math.min(manaShift, attacker.stamina); //This also needs to be commented awaay if we want to remove stamina cost.
 
         attacker._manaCap = Math.max(attacker._manaCap, attacker.mana + manaShift);
         //attacker.hitStamina(manaShift);


### PR DESCRIPTION
Mana surge didn't cost Stamina anymore, but how much Mana you recovered was still limited by how much Stamina you had. This is now fixed.

Commented away instead of deleting, because Stamina cost is planned to make a return at a later date.